### PR TITLE
Add missing paragraph separator

### DIFF
--- a/bley.1
+++ b/bley.1
@@ -23,5 +23,6 @@ use verbose output
 .TP
 \fB\-d\fR, \fB\-\-debug\fR
 don't daemonize the process and log to stdout
+.TP
 \fB\-f\fR, \fB\-\-foreground\fR
 don't daemonize the process


### PR DESCRIPTION
The man page paragraphs for "-d" and "-f" are not separate.  Adding a missing ".TP" separator makes the man page more readable.