### PR TITLE
skip tests that require network by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,7 @@ jobs:
     env:
       PYTHON: ${{ matrix.python }}
       TWISTED_VERSION: ${{ matrix.twisted }}
+      BLEY_TEST_ALLOW_NETWORK: "true"
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/test/test_bley.py
+++ b/test/test_bley.py
@@ -1,3 +1,4 @@
+import os
 from bley.postfix import PostfixPolicy
 from twisted.trial import unittest
 from twisted.internet.protocol import ClientFactory
@@ -436,6 +437,9 @@ class BleyTestCase(unittest.TestCase):
         return self._test_whitelist_client_ip(ip)
 
     def test_dnsbl_client(self):
+        if os.environ.get('BLEY_TEST_ALLOW_NETWORK', 'false') != 'true':
+            raise unittest.SkipTest('test requires network access')
+
         data = {
             'sender': 'root@example.com',
             'recipient': 'user@example.com',
@@ -450,6 +454,9 @@ class BleyTestCase(unittest.TestCase):
         return d
 
     def test_dnsbl_rfc_client(self):
+        if os.environ.get('BLEY_TEST_ALLOW_NETWORK', 'false') != 'true':
+            raise unittest.SkipTest('test requires network access')
+
         data = {
             'sender': 'root@example.com',
             'recipient': 'user@example.com',

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,8 @@ deps =
     publicsuffix2
     Twisted=={env:TWISTED_VERSION:20.3.0}
 allowlist_externals=make
+passenv =
+    BLEY_TEST_ALLOW_NETWORK
 
 [gh-actions]
 python =


### PR DESCRIPTION
enable by setting `BLEY_TEST_ALLOW_NETWORK=true`