### PR TITLE
epel9

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -28,3 +28,4 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-stable
+      - epel-9

--- a/bley.spec
+++ b/bley.spec
@@ -11,7 +11,7 @@ BuildArch:      noarch
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 
-Requires:       python3-mysql
+Requires:       python3-mysqlclient
 Requires:       python3-py3dns
 Requires:       python3-pyspf
 Requires:       python3-psycopg2


### PR DESCRIPTION
- **use python3-mysqlclient, python3-mysql is just an alias**
- **enable installation tests on EPEL9**
