### PR TITLE
replace ix.dnsbl.manitu.net with zen.spamhaus.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ the message sent via
 
 The DNSWLs and DNSBLs `bley` uses for its tests can be set via
 
-    dnsbls = ix.dnsbl.manitu.net
+    dnsbls = zen.spamhaus.org
     dnswls = list.dnswl.org
 
 Thresholds define how many sub-checks have to hit, to trigger a feature

--- a/bley.conf.example
+++ b/bley.conf.example
@@ -25,7 +25,7 @@
 #whitelist_clients_file = ./whitelist_clients
 
 # Which DNSBLs and DNSWLs to use?
-#dnsbls = ix.dnsbl.manitu.net
+#dnsbls = zen.spamhaus.org
 #dnswls = list.dnswl.org
 
 # Whitelist after dnswl_threshold hits.

--- a/bley/bley.py
+++ b/bley/bley.py
@@ -61,7 +61,7 @@ DEFAULT_CONFIG = {
     'dbport': '0',
     'whitelist_recipients_file': './whitelist_recipients',
     'whitelist_clients_file': './whitelist_clients',
-    'dnsbls': 'ix.dnsbl.manitu.net',
+    'dnsbls': 'zen.spamhaus.org',
     'dnswls': 'list.dnswl.org',
     'dnswl_threshold': '1',
     'dnsbl_threshold': '1',


### PR DESCRIPTION
[1] https://hostblogger.de/blog/archives/7353-Die-AEra-der-ix.dnsbl.manitu.net-geht-zu-Ende.html
